### PR TITLE
Local Issue 해결해보았습니다.

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>  
+<html lang="ko">
+<head>  
+<title>Example</title>
+<meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />  
+ 
+<link rel="stylesheet" href="/nanumbarungothic.css" />
+<style type="text/css">
+body {
+	font-family:'Nanum Barun Gothic';
+	font-size:30px;
+	line-height:40px;
+}
+span {
+	display:block;
+}
+span.span200 {font-weight:200;}
+span.span300 {font-weight:300;}
+span.span400 {font-weight:400;}
+span.span700 {font-weight:700;}
+</style>
+ 
+</head>  
+<body>
+ 
+<span class="span span200">나눔바른고딕 Font Weight : 200</span>
+<span class="span span300">나눔바른고딕 Font Weight : 300</span>
+<span class="span span400">나눔바른고딕 Font Weight : 400</span>
+<span class="span span700">나눔바른고딕 Font Weight : 700</span>
+
+</body>  
+</html> 

--- a/nanumbarungothic.css
+++ b/nanumbarungothic.css
@@ -5,9 +5,10 @@
   font-family: 'Nanum Barun Gothic';
   font-style: normal;
   font-weight: 200;
-  src: local('Nanum Barun Gothic UltraLight'), local('Nanum Barun Gothic-UltraLight'), local('NanumBarunGothic UltraLight');
   src: url(./NanumBarunGothicUltraLight.eot);
-  src: url(./NanumBarunGothicUltraLight.eot?#iefix) format('embedded-opentype'),
+  src: local('Nanum Barun Gothic UltraLight'),
+       local('NanumBarunGothicUltraLight'),
+       url(./NanumBarunGothicUltraLight.eot?#iefix) format('embedded-opentype'),
        url(./NanumBarunGothicUltraLight.woff2) format('woff2'),
        url(./NanumBarunGothicUltraLight.woff) format('woff'),
        url(./NanumBarunGothicUltraLight.ttf) format('truetype');
@@ -17,9 +18,10 @@
   font-family: 'Nanum Barun Gothic';
   font-style: normal;
   font-weight: 300;
-  src: local('Nanum Barun Gothic Light'), local('Nanum Barun Gothic-Light'), local('NanumBarunGothic Light');
   src: url(./NanumBarunGothicLight.eot);
-  src: url(./NanumBarunGothicLight.eot?#iefix) format('embedded-opentype'),
+  src: local('Nanum Barun Gothic Light'),
+       local('NanumBarunGothicLight'),
+       url(./NanumBarunGothicLight.eot?#iefix) format('embedded-opentype'),
        url(./NanumBarunGothicLight.woff2) format('woff2'),
        url(./NanumBarunGothicLight.woff) format('woff'),
        url(./NanumBarunGothicLight.ttf) format('truetype');
@@ -29,9 +31,10 @@
   font-family: 'Nanum Barun Gothic';
   font-style: normal;
   font-weight: 400;
-  src: local('Nanum Barun Gothic Regular'), local('Nanum Barun Gothic-Regular'), local('NanumBarunGothic Regular');
   src: url(./NanumBarunGothic.eot);
-  src: url(./NanumBarunGothic.eot?#iefix) format('embedded-opentype'),
+  src: local('Nanum Barun Gothic'),
+       local('NanumBarunGothic'),
+       url(./NanumBarunGothic.eot?#iefix) format('embedded-opentype'),
        url(./NanumBarunGothic.woff2) format('woff2'),
        url(./NanumBarunGothic.woff) format('woff'),
        url(./NanumBarunGothic.ttf) format('truetype');
@@ -41,9 +44,10 @@
   font-family: 'Nanum Barun Gothic';
   font-style: normal;
   font-weight: 700;
-  src: local('Nanum Barun Gothic Bold'), local('Nanum Barun Gothic-Bold'), local('NanumBarunGothic Bold');
   src: url(./NanumBarunGothicBold.eot);
-  src: url(./NanumBarunGothicBold.eot?#iefix) format('embedded-opentype'),
+  src: local('Nanum Barun Gothic Bold'),
+       local('NanumBarunGothicBold'),
+       url(./NanumBarunGothicBold.eot?#iefix) format('embedded-opentype'),
        url(./NanumBarunGothicBold.woff2) format('woff2'),
        url(./NanumBarunGothicBold.woff) format('woff'),
        url(./NanumBarunGothicBold.ttf) format('truetype');


### PR DESCRIPTION
일단 테스트를 위해서 부득이 example.html 파일을 추가하였습니다.

@font-face 내부에 src가 3개가 있으면 맨 마지막것을 기준으로 잡기 때문에 첫번째에 있는 local경로를 타지 않는 문제가 있었습니다. 그래서 기존 첫번째 src(local(...))하고 세번째 src(woff2, woff, ttf 정의된)를 합쳤습니다. 

그리고 기존에 두번째 있고 지금은 첫번째 있는 (단독으로 사용중인) src의 경우 IE8에서 해당 소스를 통해 구동되는 것을 확인하였습니다.

테스트는 다음 두 환경에서 진행하였습니다.

OS : OSX 10.10.1
Browser : Chrome 39, Safari 8, Firefox Develop Edition 36

OS : Window XP
Browser : IE8

그리고 각각에 대해서 로컬에 나눔바른고딕이 설치된 경우와 설치되어있지 않은 경우 해당 화면이 제대로 나오는지 확인하였습니다.
단, IE8의 경우 로컬에 설치되어있어도 `src: url(./NanumBarunGothic.eot);`를 기준으로 css가 실행됩니다.

아, 한가지 더, 이슈 등록된 내용이 무슨말인가 했더니 Regular 소스의 경우 Local 이름에 `local('Nanum Barun Gothic Regular')`가 아니라 `local('Nanum Barun Gothic')`로 집어넣어야 한다는 내용이었습니다.


