### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Web Font Version of Nanum Barun Gothic. Created by [NAVER](http://www.naver.com)
 - Light(300)
 - UltraLight(200)
 
-##Formats
+## Formats
 
 - ttf
 - eot
@@ -54,6 +54,6 @@ body {
 
 [kaiserjun](https://github.com/kaiserjun) - Issuing about conversion error in `.woff` format font.
 
-##License
+## License
 
 Copyright (c) 2010, NAVER Corporation (http://www.nhncorp.com)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
